### PR TITLE
fix: refactor env var resolution to support complex structures and fix in-place mutation bug

### DIFF
--- a/backend/src/config/app_config.py
+++ b/backend/src/config/app_config.py
@@ -72,7 +72,7 @@ class AppConfig(BaseModel):
         resolved_path = cls.resolve_config_path(config_path)
         with open(resolved_path) as f:
             config_data = yaml.safe_load(f)
-        cls.resolve_env_variables(config_data)
+        config_data = cls.resolve_env_variables(config_data)
 
         # Load title config if present
         if "title" in config_data:

--- a/backend/src/config/app_config.py
+++ b/backend/src/config/app_config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
 import yaml
 from dotenv import load_dotenv
@@ -90,7 +90,7 @@ class AppConfig(BaseModel):
         return result
 
     @classmethod
-    def resolve_env_variables(cls, config: dict) -> dict:
+    def resolve_env_variables(cls, config: Any) -> Any:
         """Recursively resolve environment variables in the config.
 
         Environment variables are resolved using the `os.getenv` function. Example: $OPENAI_API_KEY
@@ -101,18 +101,14 @@ class AppConfig(BaseModel):
         Returns:
             The config with environment variables resolved.
         """
-        for key, value in config.items():
-            if isinstance(value, str):
-                if value.startswith("$"):
-                    env_value = os.getenv(value[1:], None)
-                    if env_value is not None:
-                        config[key] = env_value
-                else:
-                    config[key] = value
-            elif isinstance(value, dict):
-                config[key] = cls.resolve_env_variables(value)
-            elif isinstance(value, list):
-                config[key] = [cls.resolve_env_variables(item) for item in value]
+        if isinstance(config, str):
+            if config.startswith("$"):
+                return os.getenv(config[1:], config)
+            return config
+        elif isinstance(config, dict):
+            return {k: cls.resolve_env_variables(v) for k, v in config.items()}
+        elif isinstance(config, list):
+            return [cls.resolve_env_variables(item) for item in config]
         return config
 
     def get_model_config(self, name: str) -> ModelConfig | None:

--- a/backend/src/sandbox/sandbox.py
+++ b/backend/src/sandbox/sandbox.py
@@ -27,7 +27,7 @@ class Sandbox(ABC):
 
     @abstractmethod
     def read_file(self, path: str) -> str:
-        """Read tge content of a file.
+        """Read the content of a file.
 
         Args:
             path: The absolute path of the file to read.


### PR DESCRIPTION
## Summary
This PR refactors the resolve_env_variables method in AppConfig to robustly handle environment variable substitution in nested configuration structures (lists, dicts). It also fixes a bug where the resolved configuration was discarded due to ignoring the return value.

## Changes
- Refactor resolve_env_variables :
  - Changed from in-place mutation (which failed for lists and strings) to a functional approach returning the resolved object.
  - Added support for resolving environment variables within lists (e.g., ["$VAR1", "$VAR2"] ).
  - Improved type hinting to Any to reflect recursive nature.
- Fix AppConfig.from_file :
  - Now correctly assigns the return value of resolve_env_variables back to config_data .
- Typo Fix :
  - Corrected "tge" to "the" in backend/src/sandbox/sandbox.py docstring.
## Impact
- Configuration files can now use environment variables in list fields.
- Prevents potential crashes when parsing list-based configurations.
- Ensures environment variables are actually substituted in the final app config.
## Verification
- Verified manually with a reproduction script that ["$TEST_VAR"] style configs are correctly resolved.
- Verified that existing dictionary-based configs continue to work.