### PR TITLE
feat:add horizontal divider before each h2 heading in markdown content

### DIFF
--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -301,15 +301,40 @@ export const MessageBranchPage = ({
   );
 };
 
+const MarkdownH2 = memo(
+  ({ children, className, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
+    <>
+      <hr className="my-6 border-border" data-streamdown="horizontal-rule" />
+      <h2
+        className={cn(
+          "mt-6 mb-2 font-semibold text-2xl",
+          className
+        )}
+        data-streamdown="heading-2"
+        {...props}
+      >
+        {children}
+      </h2>
+    </>
+  ),
+  (prevProps, nextProps) => prevProps.children === nextProps.children,
+);
+
+MarkdownH2.displayName = "MarkdownH2WithDivider";
+
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
+  ({ className, components, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className,
       )}
+      components={{
+        h2: MarkdownH2,
+        ...components, // allow external overrides
+      }}
       {...props}
     />
   ),


### PR DESCRIPTION
  ## What
  Add a horizontal divider (`<hr>`) before each h2 heading in markdown content rendered by Streamdown, improving visual separation between major content sections.

  ## How
  - Created a custom `MarkdownH2` component that renders an `<hr>` element before each `<h2>`
  - Leveraged Streamdown's `components` prop to override the default h2 renderer
  - The divider uses the same Tailwind classes as existing horizontal rules for visual consistency

  ## Changes
  - **Modified**: `frontend/src/components/ai-elements/message.tsx`
    - Added `Components` type import from `react-markdown`
    - Created `MarkdownH2` component with divider
    - Updated `MessageResponse` to use custom h2 renderer

  ## Screenshot
  Before: h2 headings without dividers
  After: h2 headings with horizontal dividers for better visual separation

  ## Notes
  - The divider appears before every h2 heading, including the first one
  - External consumers can still override the h2 component via the `components` prop
  - Uses existing design tokens (`border-border`) for theme consistency

<img width="1445" height="1029" alt="4c5648604bac91487237ab3cb4d92749" src="https://github.com/user-attachments/assets/1e1c6ac3-7366-4a13-8ffa-66b909bb957f" />
<img width="1425" height="1127" alt="1cb1302e5b046ce401263da78c18c468" src="https://github.com/user-attachments/assets/fdf6fff4-4a7f-4327-93e5-18f19b8352ff" />
