### PR TITLE
fix: 修复用户消息中上传文件的右对齐显示

### DIFF
--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -332,7 +332,7 @@ function UploadedFilesList({
   if (files.length === 0) return null;
 
   return (
-    <div className="mb-2 flex flex-wrap gap-2">
+    <div className="mb-2 flex flex-wrap justify-end gap-2">
       {files.map((file, index) => (
         <UploadedFileCard
           key={`${file.path}-${index}`}


### PR DESCRIPTION
在 UploadedFilesList 组件中添加 justify-end 类，确保上传的文件卡片在用户消息中保持右对齐显示，与消息气泡对齐一致。