### PR TITLE
Adds StatefulSet pod-sticky sandbox routing for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ Setup Kubernetes sandbox as per [Kubernetes Sandbox Setup](docker/k8s/README.md)
 Then configure `config.yaml` with the Kubernetes service URL:
 ```yaml
 sandbox:
-   use: src.community.k8s_sandbox:AioSandboxProvider # Kubernetes-based sandbox
-   base_url: http://deer-flow-sandbox.deer-flow.svc.cluster.local:8080 # Kubernetes service URL
+   use: src.community.aio_sandbox:AioSandboxProvider # Kubernetes-based sandbox
+   base_url: http://deer-flow-sandbox-{pod_index}.deer-flow-sandbox.deer-flow.svc.cluster.local:8080 # Kubernetes StatefulSet pod URL
+   replicas: 3 # Must match StatefulSet replicas count
 ```
 
 ## Features

--- a/backend/src/config/sandbox_config.py
+++ b/backend/src/config/sandbox_config.py
@@ -50,6 +50,10 @@ class SandboxConfig(BaseModel):
         default=None,
         description="Prefix for container names",
     )
+    replicas: int | None = Field(
+        default=None,
+        description="Number of StatefulSet replicas for Kubernetes pod-sticky routing. Used with {pod_index} placeholder in base_url to enable consistent routing of the same thread to the same pod.",
+    )
     idle_timeout: int | None = Field(
         default=None,
         description="Idle timeout in seconds before sandbox is released (default: 600 = 10 minutes). Set to 0 to disable.",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -155,6 +155,12 @@ sandbox:
 #   # Optional: Use existing sandbox at this URL (no container will be started)
 #   # base_url: http://localhost:8080
 #
+#   # Optional: Kubernetes StatefulSet mode for pod-sticky routing
+#   # Use {pod_index} placeholder in base_url with replicas to ensure the same
+#   # thread always routes to the same pod (consistent hashing on thread_id).
+#   # base_url: http://deer-flow-sandbox-{pod_index}.deer-flow-sandbox.deer-flow.svc.cluster.local:8080
+#   # replicas: 3  # Must match the StatefulSet replicas count
+#
 #   # Optional: Container image to use (works with both Docker and Apple Container)
 #   # Default: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 #   # Recommended: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest (works on both x86_64 and arm64)

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -84,7 +84,7 @@ services:
       context: ../
       dockerfile: backend/Dockerfile
     container_name: deer-flow-langgraph
-    command: sh -c "cd backend && uv run langgraph dev --no-browser --allow-blocking --host 0.0.0.0 --port 2024 > /app/logs/langgraph.log 2>&1"
+    command: sh -c "cd backend && NO_COLOR=1 uv run langgraph dev --no-browser --allow-blocking --host 0.0.0.0 --port 2024 > /app/logs/langgraph.log 2>&1"
     volumes:
       - ../backend/src:/app/backend/src
       - ../backend/.env:/app/backend/.env

--- a/docker/k8s/sandbox-deployment.yaml
+++ b/docker/k8s/sandbox-deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: deer-flow-sandbox
   namespace: deer-flow
@@ -7,7 +7,9 @@ metadata:
     app.kubernetes.io/name: deer-flow
     app.kubernetes.io/component: sandbox
 spec:
-  replicas: 1
+  serviceName: deer-flow-sandbox
+  replicas: 3 # Set to 1 for single instance, or more for multiple isolated sandboxes
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: deer-flow-sandbox

--- a/docker/k8s/setup.sh
+++ b/docker/k8s/setup.sh
@@ -110,8 +110,8 @@ verify_deployment() {
     echo "  → Checking service..."
     kubectl get service -n deer-flow
     
-    echo "  → Checking deployment..."
-    kubectl get deployment -n deer-flow
+    echo "  → Checking statefulset..."
+    kubectl get statefulset -n deer-flow
     
     echo "  → Checking pods..."
     kubectl get pods -n deer-flow
@@ -155,7 +155,8 @@ print_next_steps() {
     echo
     echo -e "${GREEN}sandbox:${NC}"
     echo -e "${GREEN}  use: src.community.aio_sandbox:AioSandboxProvider${NC}"
-    echo -e "${GREEN}  base_url: http://deer-flow-sandbox.deer-flow.svc.cluster.local:8080${NC}"
+    echo -e "${GREEN}  base_url: http://deer-flow-sandbox-{pod_index}.deer-flow-sandbox.deer-flow.svc.cluster.local:8080${NC}"
+    echo -e "${GREEN}  replicas: 1  # Match the replicas count in sandbox-deployment.yaml${NC}"
     echo
     echo
     echo -e "${GREEN}Next steps:${NC}"


### PR DESCRIPTION
Enables exclusive thread-to-pod mapping via DNS-based URLs with a {pod_index} placeholder and replica count, ensuring consistent sandbox isolation and direct pod access. Updates docs, config, and setup scripts to reflect StatefulSet usage and routing scheme.

Improves multi-sandbox scalability and reliability in Kubernetes.