### PR TITLE
feat(harness): add tool-first ACP agent invocation

### DIFF
--- a/backend/packages/harness/deerflow/config/acp_config.py
+++ b/backend/packages/harness/deerflow/config/acp_config.py
@@ -1,0 +1,39 @@
+"""ACP (Agent Client Protocol) agent configuration loaded from config.yaml."""
+
+import logging
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class ACPAgentConfig(BaseModel):
+    """Configuration for a single ACP-compatible agent."""
+
+    command: str = Field(description="Command to launch the ACP agent subprocess")
+    args: list[str] = Field(default_factory=list, description="Additional command arguments")
+    description: str = Field(description="Description of the agent's capabilities (shown in tool description)")
+    model: str | None = Field(default=None, description="Model hint passed to the agent (optional)")
+
+
+_acp_agents: dict[str, ACPAgentConfig] = {}
+
+
+def get_acp_agents() -> dict[str, ACPAgentConfig]:
+    """Get the currently configured ACP agents.
+
+    Returns:
+        Mapping of agent name -> ACPAgentConfig.  Empty dict if no ACP agents are configured.
+    """
+    return _acp_agents
+
+
+def load_acp_config_from_dict(config_dict: dict) -> None:
+    """Load ACP agent configuration from a dictionary (typically from config.yaml).
+
+    Args:
+        config_dict: Mapping of agent name -> config fields.
+    """
+    global _acp_agents
+    _acp_agents = {name: ACPAgentConfig(**cfg) for name, cfg in config_dict.items()}
+    logger.info("ACP config loaded: %d agent(s): %s", len(_acp_agents), list(_acp_agents.keys()))

--- a/backend/packages/harness/deerflow/config/acp_config.py
+++ b/backend/packages/harness/deerflow/config/acp_config.py
@@ -1,6 +1,7 @@
 """ACP (Agent Client Protocol) agent configuration loaded from config.yaml."""
 
 import logging
+from collections.abc import Mapping
 
 from pydantic import BaseModel, Field
 
@@ -28,12 +29,14 @@ def get_acp_agents() -> dict[str, ACPAgentConfig]:
     return _acp_agents
 
 
-def load_acp_config_from_dict(config_dict: dict) -> None:
+def load_acp_config_from_dict(config_dict: Mapping[str, Mapping[str, object]] | None) -> None:
     """Load ACP agent configuration from a dictionary (typically from config.yaml).
 
     Args:
         config_dict: Mapping of agent name -> config fields.
     """
     global _acp_agents
+    if config_dict is None:
+        config_dict = {}
     _acp_agents = {name: ACPAgentConfig(**cfg) for name, cfg in config_dict.items()}
     logger.info("ACP config loaded: %d agent(s): %s", len(_acp_agents), list(_acp_agents.keys()))

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -7,6 +7,7 @@ import yaml
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field
 
+from deerflow.config.acp_config import load_acp_config_from_dict
 from deerflow.config.checkpointer_config import CheckpointerConfig, load_checkpointer_config_from_dict
 from deerflow.config.extensions_config import ExtensionsConfig
 from deerflow.config.guardrails_config import load_guardrails_config_from_dict
@@ -115,6 +116,9 @@ class AppConfig(BaseModel):
         # Load checkpointer config if present
         if "checkpointer" in config_data:
             load_checkpointer_config_from_dict(config_data["checkpointer"])
+
+        # Always refresh ACP agent config so removed entries do not linger across reloads.
+        load_acp_config_from_dict(config_data.get("acp_agents", {}))
 
         # Load extensions config separately (it's in a different file)
         extensions_config = ExtensionsConfig.from_file()

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -105,7 +105,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
         except ImportError:
             return (
                 "Error: agent-client-protocol package is not installed. "
-                "Install it with: uv sync --extra acp"
+                "Run `uv sync` to install project dependencies."
             )
 
         class _CollectingClient(Client):

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -1,0 +1,168 @@
+"""Built-in tool for invoking external ACP-compatible agents."""
+
+import logging
+import os
+from typing import Any
+
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class _InvokeACPAgentInput(BaseModel):
+    agent: str = Field(description="Name of the ACP agent to invoke")
+    prompt: str = Field(description="The task prompt to send to the agent")
+    cwd: str | None = Field(
+        default=None,
+        description="Working directory for the agent subprocess. "
+        "Use /mnt/user-data/workspace to run in the thread workspace. "
+        "Defaults to the current thread's workspace when available.",
+    )
+
+
+def _resolve_cwd(cwd: str | None) -> str:
+    """Resolve cwd: translate virtual paths and apply thread-workspace default.
+
+    Args:
+        cwd: Virtual or physical path, or None to use the thread workspace default.
+
+    Returns:
+        An absolute physical filesystem path to use as the working directory.
+    """
+    if cwd is None:
+        # Try to use the current thread's workspace directory
+        try:
+            from langgraph.config import get_config
+
+            config = get_config()
+            thread_id = config.get("configurable", {}).get("thread_id")
+            if thread_id:
+                from deerflow.config.paths import get_paths
+
+                workspace = get_paths().sandbox_work_dir(thread_id)
+                if workspace.exists():
+                    return str(workspace)
+        except Exception:
+            pass
+        return os.path.abspath(os.getcwd())
+
+    # Translate DeerFlow virtual paths (/mnt/user-data/...) to physical paths
+    from deerflow.config.paths import VIRTUAL_PATH_PREFIX
+
+    if cwd.startswith(VIRTUAL_PATH_PREFIX) or cwd.startswith("/mnt/user-data"):
+        try:
+            from langgraph.config import get_config
+
+            config = get_config()
+            thread_id = config.get("configurable", {}).get("thread_id")
+            if thread_id:
+                from deerflow.config.paths import get_paths
+
+                return str(get_paths().resolve_virtual_path(thread_id, cwd))
+        except Exception as e:
+            logger.warning("Failed to translate virtual path %r: %s", cwd, e)
+
+    return os.path.abspath(cwd)
+
+
+def _build_mcp_servers() -> dict[str, dict[str, Any]]:
+    """Build ACP ``mcpServers`` config from DeerFlow's enabled MCP servers."""
+    from deerflow.config.extensions_config import get_extensions_config
+    from deerflow.mcp.client import build_servers_config
+
+    return build_servers_config(get_extensions_config())
+
+
+def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
+    """Create the ``invoke_acp_agent`` tool with a description generated from configured agents.
+
+    The tool description includes the list of available agents so that the LLM
+    knows which agents it can invoke without requiring hardcoded names.
+
+    Args:
+        agents: Mapping of agent name -> ``ACPAgentConfig``.
+
+    Returns:
+        A LangChain ``BaseTool`` ready to be included in the tool list.
+    """
+    agent_lines = "\n".join(f"- {name}: {cfg.description}" for name, cfg in agents.items())
+    description = f"Invoke an external ACP-compatible agent and return its final response.\n\nAvailable agents:\n{agent_lines}"
+
+    # Capture agents in closure so the function can reference it
+    _agents = dict(agents)
+
+    async def _invoke(agent: str, prompt: str, cwd: str | None = None) -> str:
+        if agent not in _agents:
+            available = ", ".join(_agents.keys())
+            return f"Error: Unknown agent '{agent}'. Available: {available}"
+
+        agent_config = _agents[agent]
+
+        try:
+            from acp import PROTOCOL_VERSION, Client, RequestError, text_block
+            from acp.schema import ClientCapabilities, Implementation
+        except ImportError:
+            return (
+                "Error: agent-client-protocol package is not installed. "
+                "Install it with: uv sync --extra acp"
+            )
+
+        class _CollectingClient(Client):
+            """Minimal ACP Client that collects streamed text from session updates."""
+
+            def __init__(self) -> None:
+                self._chunks: list[str] = []
+
+            @property
+            def collected_text(self) -> str:
+                return "".join(self._chunks)
+
+            async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
+                try:
+                    from acp.schema import TextContentBlock
+
+                    if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
+                        self._chunks.append(update.content.text)
+                except Exception:
+                    pass
+
+            async def request_permission(self, options, session_id: str, tool_call, **kwargs):  # type: ignore[override]
+                raise RequestError.method_not_found("session/request_permission")
+
+        client = _CollectingClient()
+        cmd = agent_config.command
+        args = agent_config.args or []
+        physical_cwd = _resolve_cwd(cwd)
+        mcp_servers = _build_mcp_servers()
+
+        try:
+            from acp import spawn_agent_process
+
+            async with spawn_agent_process(client, cmd, *args, cwd=physical_cwd) as (conn, proc):
+                await conn.initialize(
+                    protocol_version=PROTOCOL_VERSION,
+                    client_capabilities=ClientCapabilities(),
+                    client_info=Implementation(name="deerflow", title="DeerFlow", version="0.1.0"),
+                )
+                session_kwargs: dict[str, Any] = {"cwd": physical_cwd, "mcp_servers": mcp_servers}
+                if agent_config.model:
+                    session_kwargs["model"] = agent_config.model
+                session = await conn.new_session(**session_kwargs)
+                await conn.prompt(
+                    session_id=session.session_id,
+                    prompt=[text_block(prompt)],
+                )
+            result = client.collected_text
+            logger.info("ACP agent '%s' returned %d characters", agent, len(result))
+            return result or "(no response)"
+        except Exception as e:
+            logger.error("ACP agent '%s' invocation failed: %s", agent, e)
+            return f"Error invoking ACP agent '{agent}': {e}"
+
+    return StructuredTool.from_function(
+        name="invoke_acp_agent",
+        description=description,
+        coroutine=_invoke,
+        args_schema=_InvokeACPAgentInput,
+    )

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -68,10 +68,31 @@ def _resolve_cwd(cwd: str | None) -> str:
 
 def _build_mcp_servers() -> dict[str, dict[str, Any]]:
     """Build ACP ``mcpServers`` config from DeerFlow's enabled MCP servers."""
-    from deerflow.config.extensions_config import get_extensions_config
+    from deerflow.config.extensions_config import ExtensionsConfig
     from deerflow.mcp.client import build_servers_config
 
-    return build_servers_config(get_extensions_config())
+    return build_servers_config(ExtensionsConfig.from_file())
+
+
+def _build_permission_response(options: list[Any]):
+    """Auto-approve ACP permission requests one call at a time when possible."""
+    from acp import RequestPermissionResponse
+    from acp.schema import AllowedOutcome, DeniedOutcome
+
+    for preferred_kind in ("allow_once", "allow_always"):
+        for option in options:
+            if getattr(option, "kind", None) != preferred_kind:
+                continue
+
+            option_id = getattr(option, "option_id", None)
+            if option_id is None:
+                option_id = getattr(option, "optionId")
+
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(outcome="selected", optionId=option_id),
+            )
+
+    return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
 
 
 def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
@@ -100,7 +121,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
         agent_config = _agents[agent]
 
         try:
-            from acp import PROTOCOL_VERSION, Client, RequestError, text_block
+            from acp import PROTOCOL_VERSION, Client, text_block
             from acp.schema import ClientCapabilities, Implementation
         except ImportError:
             return (
@@ -128,7 +149,13 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                     pass
 
             async def request_permission(self, options, session_id: str, tool_call, **kwargs):  # type: ignore[override]
-                raise RequestError.method_not_found("session/request_permission")
+                response = _build_permission_response(options)
+                outcome = response.outcome.outcome
+                if outcome == "selected":
+                    logger.info("ACP permission auto-approved for tool call %s in session %s", tool_call.tool_call_id, session_id)
+                else:
+                    logger.warning("ACP permission denied for tool call %s in session %s", tool_call.tool_call_id, session_id)
+                return response
 
         client = _CollectingClient()
         cmd = agent_config.command

--- a/backend/packages/harness/deerflow/tools/tools.py
+++ b/backend/packages/harness/deerflow/tools/tools.py
@@ -97,5 +97,18 @@ def get_available_tools(
         except Exception as e:
             logger.error(f"Failed to get cached MCP tools: {e}")
 
-    logger.info(f"Total tools loaded: {len(loaded_tools)}, built-in tools: {len(builtin_tools)}, MCP tools: {len(mcp_tools)}")
-    return loaded_tools + builtin_tools + mcp_tools
+    # Add invoke_acp_agent tool if any ACP agents are configured
+    acp_tools: list[BaseTool] = []
+    try:
+        from deerflow.config.acp_config import get_acp_agents
+        from deerflow.tools.builtins.invoke_acp_agent_tool import build_invoke_acp_agent_tool
+
+        acp_agents = get_acp_agents()
+        if acp_agents:
+            acp_tools.append(build_invoke_acp_agent_tool(acp_agents))
+            logger.info(f"Including invoke_acp_agent tool ({len(acp_agents)} agent(s): {list(acp_agents.keys())})")
+    except Exception as e:
+        logger.warning(f"Failed to load ACP tool: {e}")
+
+    logger.info(f"Total tools loaded: {len(loaded_tools)}, built-in tools: {len(builtin_tools)}, MCP tools: {len(mcp_tools)}, ACP tools: {len(acp_tools)}")
+    return loaded_tools + builtin_tools + mcp_tools + acp_tools

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
     "langgraph-sdk>=0.1.51",
 ]
 
+[project.optional-dependencies]
+acp = ["agent-client-protocol>=0.4.0"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "DeerFlow agent harness framework"
 requires-python = ">=3.12"
 dependencies = [
+    "agent-client-protocol>=0.4.0",
     "agent-sandbox>=0.0.19",
     "dotenv>=0.9.9",
     "httpx>=0.28.0",
@@ -31,9 +32,6 @@ dependencies = [
     "langgraph-checkpoint-sqlite>=3.0.3",
     "langgraph-sdk>=0.1.51",
 ]
-
-[project.optional-dependencies]
-acp = ["agent-client-protocol>=0.4.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,9 +18,6 @@ dependencies = [
     "markdown-to-mrkdwn>=0.3.1",
 ]
 
-[project.optional-dependencies]
-acp = ["deerflow-harness[acp]"]
-
 [dependency-groups]
 dev = ["pytest>=8.0.0", "ruff>=0.14.11"]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "markdown-to-mrkdwn>=0.3.1",
 ]
 
+[project.optional-dependencies]
+acp = ["deerflow-harness[acp]"]
+
 [dependency-groups]
 dev = ["pytest>=8.0.0", "ruff>=0.14.11"]
 

--- a/backend/tests/test_acp_config.py
+++ b/backend/tests/test_acp_config.py
@@ -53,6 +53,14 @@ def test_load_acp_config_empty_clears_agents():
     assert len(get_acp_agents()) == 0
 
 
+def test_load_acp_config_none_clears_agents():
+    load_acp_config_from_dict({"agent": {"command": "cmd", "args": [], "description": "desc"}})
+    assert len(get_acp_agents()) == 1
+
+    load_acp_config_from_dict(None)
+    assert get_acp_agents() == {}
+
+
 def test_acp_agent_config_defaults():
     cfg = ACPAgentConfig(command="my-agent", description="My agent")
     assert cfg.args == []

--- a/backend/tests/test_acp_config.py
+++ b/backend/tests/test_acp_config.py
@@ -1,0 +1,124 @@
+"""Unit tests for ACP agent configuration."""
+
+import json
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from deerflow.config.acp_config import ACPAgentConfig, get_acp_agents, load_acp_config_from_dict
+from deerflow.config.app_config import AppConfig
+
+
+def setup_function():
+    """Reset ACP config before each test."""
+    load_acp_config_from_dict({})
+
+
+def test_load_acp_config_sets_agents():
+    load_acp_config_from_dict(
+        {
+            "claude_code": {
+                "command": "claude-code-acp",
+                "args": [],
+                "description": "Claude Code for coding tasks",
+                "model": None,
+            }
+        }
+    )
+    agents = get_acp_agents()
+    assert "claude_code" in agents
+    assert agents["claude_code"].command == "claude-code-acp"
+    assert agents["claude_code"].description == "Claude Code for coding tasks"
+    assert agents["claude_code"].model is None
+
+
+def test_load_acp_config_multiple_agents():
+    load_acp_config_from_dict(
+        {
+            "claude_code": {"command": "claude-code-acp", "args": [], "description": "Claude Code"},
+            "codex": {"command": "codex-acp", "args": ["--flag"], "description": "Codex CLI"},
+        }
+    )
+    agents = get_acp_agents()
+    assert len(agents) == 2
+    assert agents["codex"].args == ["--flag"]
+
+
+def test_load_acp_config_empty_clears_agents():
+    load_acp_config_from_dict({"agent": {"command": "cmd", "args": [], "description": "desc"}})
+    assert len(get_acp_agents()) == 1
+
+    load_acp_config_from_dict({})
+    assert len(get_acp_agents()) == 0
+
+
+def test_acp_agent_config_defaults():
+    cfg = ACPAgentConfig(command="my-agent", description="My agent")
+    assert cfg.args == []
+    assert cfg.model is None
+
+
+def test_acp_agent_config_with_model():
+    cfg = ACPAgentConfig(command="my-agent", description="desc", model="claude-opus-4")
+    assert cfg.model == "claude-opus-4"
+
+
+def test_acp_agent_config_missing_command_raises():
+    with pytest.raises(ValidationError):
+        ACPAgentConfig(description="No command provided")
+
+
+def test_acp_agent_config_missing_description_raises():
+    with pytest.raises(ValidationError):
+        ACPAgentConfig(command="my-agent")
+
+
+def test_get_acp_agents_returns_empty_by_default():
+    """After clearing, should return empty dict."""
+    load_acp_config_from_dict({})
+    assert get_acp_agents() == {}
+
+
+def test_app_config_reload_without_acp_agents_clears_previous_state(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    extensions_path.write_text(json.dumps({"mcpServers": {}, "skills": {}}), encoding="utf-8")
+
+    config_with_acp = {
+        "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+        "models": [
+            {
+                "name": "test-model",
+                "use": "langchain_openai:ChatOpenAI",
+                "model": "gpt-test",
+            }
+        ],
+        "acp_agents": {
+            "codex": {
+                "command": "codex-acp",
+                "args": [],
+                "description": "Codex CLI",
+            }
+        },
+    }
+    config_without_acp = {
+        "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+        "models": [
+            {
+                "name": "test-model",
+                "use": "langchain_openai:ChatOpenAI",
+                "model": "gpt-test",
+            }
+        ],
+    }
+
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+
+    config_path.write_text(yaml.safe_dump(config_with_acp), encoding="utf-8")
+    AppConfig.from_file(str(config_path))
+    assert set(get_acp_agents()) == {"codex"}
+
+    config_path.write_text(yaml.safe_dump(config_without_acp), encoding="utf-8")
+    AppConfig.from_file(str(config_path))
+    assert get_acp_agents() == {}

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -1,0 +1,357 @@
+"""Tests for the built-in ACP invocation tool."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from deerflow.config.acp_config import ACPAgentConfig
+from deerflow.config.extensions_config import ExtensionsConfig, McpServerConfig, set_extensions_config
+from deerflow.tools.builtins.invoke_acp_agent_tool import (
+    _build_mcp_servers,
+    _resolve_cwd,
+    build_invoke_acp_agent_tool,
+)
+from deerflow.tools.tools import get_available_tools
+
+
+def test_build_mcp_servers_filters_disabled_and_maps_transports():
+    set_extensions_config(
+        ExtensionsConfig(
+            mcp_servers={
+                "stdio": McpServerConfig(enabled=True, type="stdio", command="npx", args=["srv"]),
+                "http": McpServerConfig(enabled=True, type="http", url="https://example.com/mcp"),
+                "disabled": McpServerConfig(enabled=False, type="stdio", command="echo"),
+            },
+            skills={},
+        )
+    )
+
+    try:
+        assert _build_mcp_servers() == {
+            "stdio": {"transport": "stdio", "command": "npx", "args": ["srv"]},
+            "http": {"transport": "http", "url": "https://example.com/mcp"},
+        }
+    finally:
+        set_extensions_config(ExtensionsConfig(mcp_servers={}, skills={}))
+
+
+@pytest.mark.anyio
+async def test_build_invoke_tool_description_and_unknown_agent_error():
+    tool = build_invoke_acp_agent_tool(
+        {
+            "codex": ACPAgentConfig(command="codex-acp", description="Codex CLI"),
+            "claude_code": ACPAgentConfig(command="claude-code-acp", description="Claude Code"),
+        }
+    )
+
+    assert "Available agents:" in tool.description
+    assert "- codex: Codex CLI" in tool.description
+    assert "- claude_code: Claude Code" in tool.description
+
+    result = await tool.coroutine(agent="missing", prompt="do work")
+    assert result == "Error: Unknown agent 'missing'. Available: codex, claude_code"
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_forwards_workspace_mcp_and_model(monkeypatch, tmp_path):
+    thread_id = "thread-123"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "langgraph.config",
+        SimpleNamespace(get_config=lambda: {"configurable": {"thread_id": thread_id}}),
+    )
+
+    class DummyPaths:
+        def sandbox_work_dir(self, incoming_thread_id: str) -> Path:
+            assert incoming_thread_id == thread_id
+            return workspace
+
+        def resolve_virtual_path(self, incoming_thread_id: str, virtual_path: str) -> Path:
+            assert incoming_thread_id == thread_id
+            assert virtual_path == "/mnt/user-data/uploads"
+            return uploads
+
+    monkeypatch.setattr("deerflow.config.paths.get_paths", lambda: DummyPaths())
+
+    set_extensions_config(
+        ExtensionsConfig(
+            mcp_servers={
+                "github": McpServerConfig(enabled=True, type="stdio", command="npx", args=["github-mcp"])
+            },
+            skills={},
+        )
+    )
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        @property
+        def collected_text(self) -> str:
+            return "".join(self._chunks)
+
+        async def session_update(self, session_id: str, update, **kwargs) -> None:
+            if hasattr(update, "content") and hasattr(update.content, "text"):
+                self._chunks.append(update.content.text)
+
+        async def request_permission(self, options, session_id: str, tool_call, **kwargs):
+            raise AssertionError("request_permission should not be called in this test")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            captured["initialize"] = kwargs
+
+        async def new_session(self, **kwargs):
+            captured["new_session"] = kwargs
+            return SimpleNamespace(session_id="session-1")
+
+        async def prompt(self, **kwargs):
+            captured["prompt"] = kwargs
+            client = captured["client"]
+            await client.session_update(
+                "session-1",
+                SimpleNamespace(content=text_content_block("ACP result")),
+            )
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, cwd):
+            captured["client"] = client
+            captured["spawn"] = {"cmd": cmd, "args": list(args), "cwd": cwd}
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method: str):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, cwd: DummyProcessContext(client, cmd, *args, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {"supports": []},
+            Implementation=lambda **kwargs: kwargs,
+            TextContentBlock=type(
+                "TextContentBlock",
+                (),
+                {"__init__": lambda self, text: setattr(self, "text", text)},
+            ),
+        ),
+    )
+    text_content_block = sys.modules["acp.schema"].TextContentBlock
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "codex": ACPAgentConfig(
+                command="codex-acp",
+                args=["--json"],
+                description="Codex CLI",
+                model="gpt-5-codex",
+            )
+        }
+    )
+
+    try:
+        result = await tool.coroutine(
+            agent="codex",
+            prompt="Implement the fix",
+            cwd="/mnt/user-data/uploads",
+        )
+    finally:
+        set_extensions_config(ExtensionsConfig(mcp_servers={}, skills={}))
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+        sys.modules.pop("langgraph.config", None)
+
+    assert result == "ACP result"
+    assert captured["spawn"] == {"cmd": "codex-acp", "args": ["--json"], "cwd": str(uploads)}
+    assert captured["new_session"] == {
+        "cwd": str(uploads),
+        "mcp_servers": {
+            "github": {"transport": "stdio", "command": "npx", "args": ["github-mcp"]},
+        },
+        "model": "gpt-5-codex",
+    }
+    assert captured["prompt"] == {
+        "session_id": "session-1",
+        "prompt": [{"type": "text", "text": "Implement the fix"}],
+    }
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_defaults_cwd_to_thread_workspace(monkeypatch, tmp_path):
+    thread_id = "thread-default-cwd"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "langgraph.config",
+        SimpleNamespace(get_config=lambda: {"configurable": {"thread_id": thread_id}}),
+    )
+
+    class DummyPaths:
+        def sandbox_work_dir(self, incoming_thread_id: str) -> Path:
+            assert incoming_thread_id == thread_id
+            return workspace
+
+    monkeypatch.setattr("deerflow.config.paths.get_paths", lambda: DummyPaths())
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        @property
+        def collected_text(self) -> str:
+            return "".join(self._chunks)
+
+        async def session_update(self, session_id: str, update, **kwargs) -> None:
+            if hasattr(update, "content") and hasattr(update.content, "text"):
+                self._chunks.append(update.content.text)
+
+        async def request_permission(self, options, session_id: str, tool_call, **kwargs):
+            raise AssertionError("request_permission should not be called in this test")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            captured["initialize"] = kwargs
+
+        async def new_session(self, **kwargs):
+            captured["new_session"] = kwargs
+            return SimpleNamespace(session_id="session-2")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            await client.session_update(
+                "session-2",
+                SimpleNamespace(content=text_content_block("workspace default")),
+            )
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, cwd):
+            captured["client"] = client
+            captured["spawn"] = {"cmd": cmd, "args": list(args), "cwd": cwd}
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method: str):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, cwd: DummyProcessContext(client, cmd, *args, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {"supports": []},
+            Implementation=lambda **kwargs: kwargs,
+            TextContentBlock=type(
+                "TextContentBlock",
+                (),
+                {"__init__": lambda self, text: setattr(self, "text", text)},
+            ),
+        ),
+    )
+    text_content_block = sys.modules["acp.schema"].TextContentBlock
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "codex": ACPAgentConfig(
+                command="codex-acp",
+                description="Codex CLI",
+            )
+        }
+    )
+
+    try:
+        result = await tool.coroutine(agent="codex", prompt="Inspect the repo")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+        sys.modules.pop("langgraph.config", None)
+
+    assert result == "workspace default"
+    assert captured["spawn"] == {"cmd": "codex-acp", "args": [], "cwd": str(workspace)}
+    assert captured["new_session"] == {
+        "cwd": str(workspace),
+        "mcp_servers": {},
+    }
+
+
+def test_resolve_cwd_defaults_to_os_cwd_when_thread_workspace_missing(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(sys.modules, "langgraph.config", SimpleNamespace(get_config=lambda: {"configurable": {}}))
+    assert _resolve_cwd(None) == str(tmp_path)
+    sys.modules.pop("langgraph.config", None)
+
+
+def test_get_available_tools_includes_invoke_acp_agent_when_agents_configured(monkeypatch):
+    from deerflow.config.acp_config import load_acp_config_from_dict
+
+    load_acp_config_from_dict(
+        {
+            "codex": {
+                "command": "codex-acp",
+                "args": [],
+                "description": "Codex CLI",
+            }
+        }
+    )
+
+    fake_config = SimpleNamespace(
+        tools=[],
+        models=[],
+        tool_search=SimpleNamespace(enabled=False),
+        get_model_config=lambda name: None,
+    )
+    monkeypatch.setattr("deerflow.tools.tools.get_app_config", lambda: fake_config)
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    tools = get_available_tools(include_mcp=True, subagent_enabled=False)
+    assert "invoke_acp_agent" in [tool.name for tool in tools]
+
+    load_acp_config_from_dict({})

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -10,6 +10,7 @@ from deerflow.config.acp_config import ACPAgentConfig
 from deerflow.config.extensions_config import ExtensionsConfig, McpServerConfig, set_extensions_config
 from deerflow.tools.builtins.invoke_acp_agent_tool import (
     _build_mcp_servers,
+    _build_permission_response,
     _resolve_cwd,
     build_invoke_acp_agent_tool,
 )
@@ -17,15 +18,19 @@ from deerflow.tools.tools import get_available_tools
 
 
 def test_build_mcp_servers_filters_disabled_and_maps_transports():
-    set_extensions_config(
-        ExtensionsConfig(
-            mcp_servers={
-                "stdio": McpServerConfig(enabled=True, type="stdio", command="npx", args=["srv"]),
-                "http": McpServerConfig(enabled=True, type="http", url="https://example.com/mcp"),
-                "disabled": McpServerConfig(enabled=False, type="stdio", command="echo"),
-            },
-            skills={},
-        )
+    set_extensions_config(ExtensionsConfig(mcp_servers={"stale": McpServerConfig(enabled=True, type="stdio", command="echo")}, skills={}))
+    fresh_config = ExtensionsConfig(
+        mcp_servers={
+            "stdio": McpServerConfig(enabled=True, type="stdio", command="npx", args=["srv"]),
+            "http": McpServerConfig(enabled=True, type="http", url="https://example.com/mcp"),
+            "disabled": McpServerConfig(enabled=False, type="stdio", command="echo"),
+        },
+        skills={},
+    )
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: fresh_config),
     )
 
     try:
@@ -34,7 +39,32 @@ def test_build_mcp_servers_filters_disabled_and_maps_transports():
             "http": {"transport": "http", "url": "https://example.com/mcp"},
         }
     finally:
+        monkeypatch.undo()
         set_extensions_config(ExtensionsConfig(mcp_servers={}, skills={}))
+
+
+def test_build_permission_response_prefers_allow_once():
+    response = _build_permission_response(
+        [
+            SimpleNamespace(kind="reject_once", optionId="deny"),
+            SimpleNamespace(kind="allow_always", optionId="always"),
+            SimpleNamespace(kind="allow_once", optionId="once"),
+        ]
+    )
+
+    assert response.outcome.outcome == "selected"
+    assert response.outcome.option_id == "once"
+
+
+def test_build_permission_response_denies_when_no_allow_option():
+    response = _build_permission_response(
+        [
+            SimpleNamespace(kind="reject_once", optionId="deny"),
+            SimpleNamespace(kind="reject_always", optionId="deny-forever"),
+        ]
+    )
+
+    assert response.outcome.outcome == "cancelled"
 
 
 @pytest.mark.anyio
@@ -80,13 +110,16 @@ async def test_invoke_acp_agent_forwards_workspace_mcp_and_model(monkeypatch, tm
 
     monkeypatch.setattr("deerflow.config.paths.get_paths", lambda: DummyPaths())
 
-    set_extensions_config(
-        ExtensionsConfig(
-            mcp_servers={
-                "github": McpServerConfig(enabled=True, type="stdio", command="npx", args=["github-mcp"])
-            },
-            skills={},
-        )
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(
+            lambda cls: ExtensionsConfig(
+                mcp_servers={
+                    "github": McpServerConfig(enabled=True, type="stdio", command="npx", args=["github-mcp"])
+                },
+                skills={},
+            )
+        ),
     )
 
     captured: dict[str, object] = {}
@@ -182,7 +215,6 @@ async def test_invoke_acp_agent_forwards_workspace_mcp_and_model(monkeypatch, tm
             cwd="/mnt/user-data/uploads",
         )
     finally:
-        set_extensions_config(ExtensionsConfig(mcp_servers={}, skills={}))
         sys.modules.pop("acp", None)
         sys.modules.pop("acp.schema", None)
         sys.modules.pop("langgraph.config", None)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -674,11 +674,6 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
-acp = [
-    { name = "deerflow-harness", extra = ["acp"] },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -688,7 +683,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "deerflow-harness", editable = "packages/harness" },
-    { name = "deerflow-harness", extras = ["acp"], marker = "extra == 'acp'", editable = "packages/harness" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "langgraph-sdk", specifier = ">=0.1.51" },
@@ -700,7 +694,6 @@ requires-dist = [
     { name = "sse-starlette", specifier = ">=2.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
-provides-extras = ["acp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -713,6 +706,7 @@ name = "deerflow-harness"
 version = "0.1.0"
 source = { editable = "packages/harness" }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "agent-sandbox" },
     { name = "ddgs" },
     { name = "dotenv" },
@@ -741,14 +735,9 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
-[package.optional-dependencies]
-acp = [
-    { name = "agent-client-protocol" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.4.0" },
+    { name = "agent-client-protocol", specifier = ">=0.4.0" },
     { name = "agent-sandbox", specifier = ">=0.0.19" },
     { name = "ddgs", specifier = ">=9.10.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
@@ -776,7 +765,6 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.17" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]
-provides-extras = ["acp"]
 
 [[package]]
 name = "defusedxml"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -14,6 +14,18 @@ resolution-markers = [
 members = [
     "deer-flow",
     "deerflow-harness",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7b/7cdac86db388809d9e3bc58cac88cc7dfa49b7615b98fab304a828cd7f8a/agent_client_protocol-0.8.1.tar.gz", hash = "sha256:1bbf15663bf51f64942597f638e32a6284c5da918055d9672d3510e965143dbd", size = 68866, upload-time = "2026-02-13T15:34:54.567Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/f3/219eeca0ad4a20843d4b9eaac5532f87018b9d25730a62a16f54f6c52d1a/agent_client_protocol-0.8.1-py3-none-any.whl", hash = "sha256:9421a11fd435b4831660272d169c3812d553bb7247049c138c3ca127e4b8af8e", size = 54529, upload-time = "2026-02-13T15:34:53.344Z" },
 ]
 
 [[package]]
@@ -662,6 +674,11 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.optional-dependencies]
+acp = [
+    { name = "deerflow-harness", extra = ["acp"] },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -671,6 +688,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "deerflow-harness", editable = "packages/harness" },
+    { name = "deerflow-harness", extras = ["acp"], marker = "extra == 'acp'", editable = "packages/harness" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "langgraph-sdk", specifier = ">=0.1.51" },
@@ -682,6 +700,7 @@ requires-dist = [
     { name = "sse-starlette", specifier = ">=2.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
+provides-extras = ["acp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -722,8 +741,14 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.optional-dependencies]
+acp = [
+    { name = "agent-client-protocol" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.4.0" },
     { name = "agent-sandbox", specifier = ">=0.0.19" },
     { name = "ddgs", specifier = ">=9.10.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
@@ -751,6 +776,7 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.17" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]
+provides-extras = ["acp"]
 
 [[package]]
 name = "defusedxml"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -330,6 +330,26 @@ sandbox:
 #       timeout_seconds: 300   # 5 minutes for quick command execution
 
 # ============================================================================
+# ACP Agents Configuration
+# ============================================================================
+# Configure external ACP-compatible agents for the built-in `invoke_acp_agent` tool.
+# Install optional ACP support first:
+#   uv sync --extra acp
+
+# acp_agents:
+#   claude_code:
+#     command: claude-code-acp
+#     args: []
+#     description: Claude Code for implementation, refactoring, and debugging
+#     model: null
+#
+#   codex:
+#     command: codex-acp
+#     args: []
+#     description: Codex CLI for repository tasks and code generation
+#     model: null
+
+# ============================================================================
 # Skills Configuration
 # ============================================================================
 # Configure skills directory for specialized agent workflows

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -333,8 +333,6 @@ sandbox:
 # ACP Agents Configuration
 # ============================================================================
 # Configure external ACP-compatible agents for the built-in `invoke_acp_agent` tool.
-# Install optional ACP support first:
-#   uv sync --extra acp
 
 # acp_agents:
 #   claude_code:


### PR DESCRIPTION
## Summary
- implement RFC #1302 as a tool-first ACP MVP via built-in `invoke_acp_agent`
- add runtime ACP agent config loading, dynamic tool registration, workspace cwd resolution, and MCP forwarding
- add tests covering config reloads, tool description/registration, path resolution, and ACP session wiring

## Validation
- `uv run --project backend pytest backend/tests/test_acp_config.py backend/tests/test_invoke_acp_agent_tool.py backend/tests/test_subagent_timeout_config.py`
- `uv run --project backend ruff check backend/packages/harness/deerflow/config/acp_config.py backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py backend/tests/test_acp_config.py backend/tests/test_invoke_acp_agent_tool.py`

## Notes
- This PR targets `feat/harness-base-20260325` in the fork because the remote `origin/feat/harness` branch is behind the current local harness baseline.